### PR TITLE
docs: add environments & URLs section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,12 +10,13 @@ This project has three deployment environments that everyone can access:
   - The live app for end users.
   - URL: [https://boilerplate-mern.platform.jalantechnologies.com](https://boilerplate-mern.platform.jalantechnologies.com)
 
-- **Preview**
-  - A preview environment for testing the latest changes.
-  - URL: [https://<github_sha>.preview.platform.jalantechnologies.com](https://<github_sha>.preview.platform.jalantechnologies.com)
+- **Preview (per PR)**
+  - A temporary environment for testing the latest changes in each PR
+  - A unique URL is generated for every pull request (e.g. `https://<github_sha>.preview.platform.jalantechnologies.com`).
 
 - **Permanent Preview**
-  - A stable preview environment that always runs the latest main branch.
+  - Always reflects the latest `main` branch.
+  - Useful for ongoing testing of the integrated codebase.
   - URL: [https://preview--boilerplate-mern.platform.jalantechnologies.com](https://preview--boilerplate-mern.platform.jalantechnologies.com)
 
 ## Table of Contents

--- a/README.md
+++ b/README.md
@@ -99,6 +99,22 @@ This project support following integrations
 
 This project deploys on Kubernetes via GitHub actions using workflows defined in [GitHub CI](https://github.com/jalantechnologies/github-ci).
 
+### Environments
+
+This project has three deployment environments that everyone can access:
+
+- **Production**
+  - The live app for end users.
+  - URL: [https://boilerplate-mern.platform.jalantechnologies.com](https://boilerplate-mern.platform.jalantechnologies.com)
+
+- **Preview**
+  - A preview environment for testing the latest changes.
+  - URL: [https://<github_sha>.preview.platform.jalantechnologies.com](https://<github_sha>.preview.platform.jalantechnologies.com)
+
+- **Permanent Preview**
+  - A stable preview environment that always runs the latest main branch.
+  - URL: [https://preview--boilerplate-mern.platform.jalantechnologies.com](https://preview--boilerplate-mern.platform.jalantechnologies.com)
+
 ## E2E Testing
 
 **Pre Requirements:**

--- a/README.md
+++ b/README.md
@@ -2,6 +2,22 @@
 
 Boilerplate project for NodeJS, React based projects in TypeScript. This README documents whatever steps are necessary to get your application up and running.
 
+### Environments & URLs
+
+This project has three deployment environments that everyone can access:
+
+- **Production**
+  - The live app for end users.
+  - URL: [https://boilerplate-mern.platform.jalantechnologies.com](https://boilerplate-mern.platform.jalantechnologies.com)
+
+- **Preview**
+  - A preview environment for testing the latest changes.
+  - URL: [https://<github_sha>.preview.platform.jalantechnologies.com](https://<github_sha>.preview.platform.jalantechnologies.com)
+
+- **Permanent Preview**
+  - A stable preview environment that always runs the latest main branch.
+  - URL: [https://preview--boilerplate-mern.platform.jalantechnologies.com](https://preview--boilerplate-mern.platform.jalantechnologies.com)
+
 ## Table of Contents
 
 - [Getting Started](#getting-started)
@@ -98,22 +114,6 @@ This project support following integrations
 ## Deployment
 
 This project deploys on Kubernetes via GitHub actions using workflows defined in [GitHub CI](https://github.com/jalantechnologies/github-ci).
-
-### Environments
-
-This project has three deployment environments that everyone can access:
-
-- **Production**
-  - The live app for end users.
-  - URL: [https://boilerplate-mern.platform.jalantechnologies.com](https://boilerplate-mern.platform.jalantechnologies.com)
-
-- **Preview**
-  - A preview environment for testing the latest changes.
-  - URL: [https://<github_sha>.preview.platform.jalantechnologies.com](https://<github_sha>.preview.platform.jalantechnologies.com)
-
-- **Permanent Preview**
-  - A stable preview environment that always runs the latest main branch.
-  - URL: [https://preview--boilerplate-mern.platform.jalantechnologies.com](https://preview--boilerplate-mern.platform.jalantechnologies.com)
 
 ## E2E Testing
 


### PR DESCRIPTION
## Description
This Pull Request adds a new section at top of `README` to describe the available environments:

- **Production**: Official live app
- **Preview**: Environment for testing latest changes
- **Permanent Preview**: Dedicated preview app accessible by all developers

This helps new developers quickly understand where to access different deployments.